### PR TITLE
🐛(acl) bugfix url matching for problem responses filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- ACL: Support filenames using `@` and `+` (e.g. course problem responses
+  report)
+
 ## [0.2.0] - 2019-05-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ help: ## display this help message
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
 
-bootstrap: run tree migrate demo-course ## bootstrap the project
+bootstrap: run migrate demo-course ## bootstrap the project
 .PHONY: bootstrap
 
 build: ## build project containers
@@ -97,7 +97,7 @@ report: ## publish test coverage report
 	$(COMPOSE_RUN) -e CODECOV_TOKEN lms codecov --commit=${CIRCLE_SHA1}
 .PHONY: report
 
-run: ## start lms development server and nginx
+run: tree ## start lms development server and nginx
 	$(COMPOSE) up -d nginx
 .PHONY: run
 

--- a/fonzie/urls/acl.py
+++ b/fonzie/urls/acl.py
@@ -12,7 +12,7 @@ from ..views.acl import ReportView
 app_name = FonzieConfig.name
 urlpatterns = [
     url(
-        r"^report/(?P<course_sha1>[a-f0-9]{40})/(?P<filename>[\d\w\-\_\.]+)$",
+        r"^report/(?P<course_sha1>[a-f0-9]{40})/(?P<filename>[\d\w\-\_\.\+\@]+)$",
         ReportView.as_view(),
         name="report",
     )

--- a/fonzie/views/status.py
+++ b/fonzie/views/status.py
@@ -4,8 +4,8 @@ API status views
 """
 from __future__ import absolute_import, unicode_literals
 
-from rest_framework.response import Response
-from rest_framework.views import APIView
+from rest_framework.response import Response  # pylint: disable=import-error
+from rest_framework.views import APIView  # pylint: disable=import-error
 
 from fonzie import __version__ as fonzie_version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,9 @@ max-line-length = 120
 ignore = D101,D104,D107,D200,D203,D212
 match-dir = (?!migrations)
 
+[tool:isort]
+known_third_party = rest_framework
+
 [tool:pytest]
 addopts =
     --reuse-db

--- a/tests/views/test_status.py
+++ b/tests/views/test_status.py
@@ -5,8 +5,8 @@ Tests for the `fonzie` views module.
 
 from __future__ import absolute_import, unicode_literals
 
-from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework import status  # pylint: disable=import-error
+from rest_framework.test import APITestCase  # pylint: disable=import-error
 
 from django.core.urlresolvers import reverse
 

--- a/tests/views/test_versioning.py
+++ b/tests/views/test_versioning.py
@@ -5,8 +5,8 @@ Tests for the `fonzie` views module.
 
 from __future__ import absolute_import, unicode_literals
 
-from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework import status  # pylint: disable=import-error
+from rest_framework.test import APITestCase  # pylint: disable=import-error
 
 from django.core.urlresolvers import reverse
 


### PR DESCRIPTION
When instructors generate course problem responses reports, filename contains
course and problem url locators which use `@` and `+`. We previously forgot
to consider this format.

fix #20 