### PR TITLE
🔖(patch) bump release to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.1] - 2019-10-10
+
 ### Fixed
 
 - ACL: Support filenames using `@` and `+` (e.g. course problem responses
   report)
+- Fix CI tree creation order
 
 ## [0.2.0] - 2019-05-21
 
@@ -24,7 +27,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `API Blueprint <https://apiblueprint.org/>`\_).
 
 
-[unreleased]: https://github.com/openfun/fonzie/compare/v0.2.0...master
+[unreleased]: https://github.com/openfun/fonzie/compare/v0.2.1...master
+[0.2.1]: https://github.com/openfun/fonzie/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/openfun/fonzie/compare/b31adef...v0.2.0
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,7 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
 #
-# html_title = 'fonzie v0.2.0'
+# html_title = 'fonzie v0.2.1'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -47,7 +47,7 @@ well:
 .. code-block:: bash
 
     $ curl http://www.mydomain.com:8080/api/v1.0/status/version
-    {"version":"0.2.0"}
+    {"version":"0.2.1"}
 
 
 Development workflow

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -85,7 +85,7 @@ project <https://httpie.org/>`_) to query the API:
     X-Frame-Options: ALLOW
 
     {
-        "version": "0.2.0"
+        "version": "0.2.1"
     }
 
 
@@ -95,7 +95,7 @@ Alternatively, you can use ``curl``:
 .. code-block:: bash
 
     $ curl http://www.mydomain.com:8080/api/v1.0/status/version
-    {"version":"0.2.0"}
+    {"version":"0.2.1"}
 
 
 The output of this command should be a JSON payload containing the running

--- a/fonzie-v1-0.apib
+++ b/fonzie-v1-0.apib
@@ -18,5 +18,5 @@ API status checking.
 + Response 200 (application/json)
 
         {
-            "version": "0.2.0"
+            "version": "0.2.1"
         }

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fonzie
-version = 0.2.0
+version = 0.2.1
 description = A FUN API for Open edX
 long_description = file: README.rst
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
Fixed:

- ACL: Support filenames using `@` and `+` (e.g. course problem responses
  report)
- Fix CI tree creation order
