### PR TITLE
♻️(api/user) use simple-jwt to generate token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add an User API endpoint to fisrt generate a JWT for Authentication purpose
   from Third Party Application
 
+### Changed
+
+- Generate JWT Token through Simple JWT's AccessToken class
+
 ## [0.2.1] - 2019-10-10
 
 ### Fixed

--- a/edx-platform/config/lms/docker_run_development.py
+++ b/edx-platform/config/lms/docker_run_development.py
@@ -40,7 +40,12 @@ REST_FRAMEWORK = {
     ],
 }
 
-JWT_PRIVATE_SIGNING_KEY = "ThisIsAnExampleKeyForDevPurposeOnly"
+SIMPLE_JWT = {
+    "ALGORITHM": "HS256",
+    "SIGNING_KEY": "ThisIsAnExampleKeyForDevPurposeOnly",
+    "USER_ID_FIELD": "username",
+    "USER_ID_CLAIM": "username",
+}
 
 FEATURES["ENABLE_DISCUSSION_SERVICE"] = False
 

--- a/tests/views/test_user.py
+++ b/tests/views/test_user.py
@@ -10,7 +10,6 @@ import jwt
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from student.tests.factories import UserFactory
@@ -45,17 +44,16 @@ class UserViewTestCase(APITestCase):
         response = self.client.get(self.url)
         token = jwt.decode(
             response.data["access_token"],
-            getattr(
-                settings,
-                "JWT_PRIVATE_SIGNING_KEY",
-                "ThisIsAnExampleKeyForDevPurposeOnly",
-            ),
-            options={"require": ["exp", "iat", "email", "username"]},
+            "ThisIsAnExampleKeyForDevPurposeOnly",
+            options={
+                "require": ["email", "exp", "iat", "jti", "token_type", "username"]
+            },
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["username"], "fonzie")
         self.assertEqual(token["username"], "fonzie")
         self.assertEqual(token["email"], "arthur_fonzarelli@fun-mooc.fr")
-        self.assertIsInstance(token["iat"], int)
+        self.assertEqual(token["token_type"], "access")
         self.assertIsInstance(token["exp"], int)
+        self.assertIsInstance(token["iat"], int)


### PR DESCRIPTION
## Purpose
Generated JWT Token should be usable with DRF Authentication system as-is through Django Rest Framework Simple JWT library (https://django-rest-framework-simplejwt.readthedocs.io/en/latest/getting_started.html).
And for other, token can still be decode as before.


## Proposal

- [x] Use Simple JWT AccessToken class to generate the jwt token
