### PR TITLE
✨(user) bind language into jwt token claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Bind user preference language into the claim of the JWT Token
+
 ## [0.3.0] - 2022-04-07
 
 ### Added

--- a/fonzie/views/user.py
+++ b/fonzie/views/user.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import AccessToken
 
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+
 
 class UserSessionView(APIView):
     """API endpoint to get the authenticated user information."""
@@ -27,12 +30,17 @@ class UserSessionView(APIView):
         """
         user = request.user
         issued_at = datetime.utcnow()
+        try:
+            language = user.preferences.get(key="pref-lang").value
+        except ObjectDoesNotExist:
+            language = settings.LANGUAGE_CODE
         token = AccessToken()
         token.payload.update(
             {
                 "email": user.email,
                 "full_name": user.profile.name,
                 "iat": issued_at,
+                "language": language,
                 "username": user.username,
             },
         )

--- a/tests/views/test_user.py
+++ b/tests/views/test_user.py
@@ -11,7 +11,9 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
+from openedx.core.djangoapps.user_api.tests.factories import UserPreferenceFactory
 from student.tests.factories import UserFactory, UserProfileFactory
 
 
@@ -33,6 +35,7 @@ class UserViewTestCase(APITestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @override_settings(LANGUAGE_CODE="de")
     def test_user_me_with_logged_in_user(self):
         """
         If user is authenticated through Django session, view should return
@@ -50,7 +53,7 @@ class UserViewTestCase(APITestCase):
             response.data["access_token"],
             "ThisIsAnExampleKeyForDevPurposeOnly",
             options={
-                "require": ["email", "exp", "iat", "jti", "token_type", "username"]
+                "require": ["email", "exp", "iat", "jti", "token_type", "username", "language"]
             },
         )
 
@@ -59,6 +62,37 @@ class UserViewTestCase(APITestCase):
         self.assertEqual(token["username"], "fonzie")
         self.assertEqual(token["full_name"], "Arthur Fonzarelli")
         self.assertEqual(token["email"], "arthur_fonzarelli@fun-mooc.fr")
+        # When the user has no language preference, LANGUAGE_CODE should be used
+        self.assertEqual(token["language"], 'de')
         self.assertEqual(token["token_type"], "access")
         self.assertIsInstance(token["exp"], int)
         self.assertIsInstance(token["iat"], int)
+
+    def test_user_me_with_logged_in_user_and_language_preference(self):
+        """
+        If user is authenticated through Django session, and it sets a language
+        in its preferences, the JWT access token returned by the view should contain
+        the language.
+        """
+        user = UserFactory.create(
+            username="joanie",
+            email="joanie_cunningham@fun-mooc.fr",
+        )
+        UserPreferenceFactory(user=user, key="pref-lang", value="fr")
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.url)
+        token = jwt.decode(
+            response.data["access_token"],
+            "ThisIsAnExampleKeyForDevPurposeOnly",
+            options={
+                "require": ["email", "exp", "iat", "jti", "token_type", "username",
+                            "language"]
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["username"], "joanie")
+        self.assertEqual(token["email"], "joanie_cunningham@fun-mooc.fr")
+        self.assertEqual(token["username"], "joanie")
+        self.assertEqual(token["language"], "fr")


### PR DESCRIPTION
## Purpose

The user language is important information that we could use from a third application. That's why we bind this information into the JWT Token claim returned by the authentication endpoint. In the case, where this preference does not exist, this attribute is set to None.


## Proposal

- [x] Retrieve user language and bind it to the JWT Token claim 
