### PR TITLE
💚(circleci) login on docker hub to download openedx-fonzie image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,9 @@ jobs:
           keys:
             - v1-edxapp-sql-dump
       - run:
+          name: Build Docker image
+          command: make build
+      - run:
           name: Start the test stack
           command: make run
       - run:


### PR DESCRIPTION
## Purpose

With docker-compose v1 when we used docker-compose up, docker built
automatically the missing image even if this is a sub dependency. With
docker-compose v2 it is no longer the case.

## Proposal

- [x] Add a step to build edxapp-fonzie image into the `test-spec` job
