### PR TITLE
🐛(user) allow to get user info even if it is inactive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: cimg/python:3.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -34,7 +34,7 @@ jobs:
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:
     docker:
-      - image: circleci/buildpack-deps:stretch-scm
+      - image: cimg/base:2023.12
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -66,7 +66,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: circleci/python:2.7-stretch
+      - image: cimg/python:2.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -87,7 +87,7 @@ jobs:
 
   build-docs:
     docker:
-      - image: circleci/python:2.7-stretch
+      - image: cimg/python:2.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -108,7 +108,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: circleci/python:2.7-stretch
+      - image: cimg/python:2.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -223,7 +223,7 @@ jobs:
   # ---- Packaging jobs ----
   package-back:
     docker:
-      - image: circleci/python:2.7-stretch
+      - image: cimg/python:2.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -254,7 +254,7 @@ jobs:
   #     environment variables in CircleCI UI (with your PyPI credentials)
   pypi:
     docker:
-      - image: circleci/python:2.7-stretch
+      - image: cimg/python:2.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-12-07
+
 ### Added
 
 - Bind user permissions into the claim of the JWT Token
@@ -54,7 +56,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `API Blueprint <https://apiblueprint.org/>`\_).
 
 
-[unreleased]: https://github.com/openfun/fonzie/compare/v0.4.0...master
+[unreleased]: https://github.com/openfun/fonzie/compare/v0.5.0...master
+[0.5.0]: https://github.com/openfun/fonzie/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/openfun/fonzie/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/openfun/fonzie/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/openfun/fonzie/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Bind user permissions into the claim of the JWT Token
+  (is_active, is_staff, is_superuser)
+
 ### Fixed
 
 - Return user information in the User API endpoint even

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Return user information in the User API endpoint even
+  if the user is not active
+
 ## [0.4.0] - 2022-07-28
 
 ### Added
@@ -49,6 +54,3 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 [0.3.0]: https://github.com/openfun/fonzie/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/openfun/fonzie/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/openfun/fonzie/compare/b31adef...v0.2.0
-
-
-

--- a/fonzie/views/user.py
+++ b/fonzie/views/user.py
@@ -2,7 +2,7 @@
 """
 API user views
 """
-
+# pylint: disable=import-error
 from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime
@@ -15,10 +15,13 @@ from rest_framework_simplejwt.tokens import AccessToken
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
+from openedx.core.lib.api.authentication import SessionAuthenticationAllowInactiveUser
+
 
 class UserSessionView(APIView):
     """API endpoint to get the authenticated user information."""
 
+    authentication_classes = [SessionAuthenticationAllowInactiveUser]
     permission_classes = [IsAuthenticated]
 
     # pylint: disable=redefined-builtin

--- a/fonzie/views/user.py
+++ b/fonzie/views/user.py
@@ -45,6 +45,9 @@ class UserSessionView(APIView):
                 "iat": issued_at,
                 "language": language,
                 "username": user.username,
+                "is_active": user.is_active,
+                "is_staff": user.is_staff,
+                "is_superuser": user.is_superuser,
             },
         )
 
@@ -52,5 +55,6 @@ class UserSessionView(APIView):
             {
                 "access_token": str(token),
                 "username": user.username,
+                "full_name": user.profile.name,
             }
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fonzie
-version = 0.4.0
+version = 0.5.0
 description = A FUN API for Open edX
 long_description = file: README.rst
 author = Open FUN (France Universite Numerique)

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ test =
     pytest-django==3.10.0
     requests==2.9.1
 ci =
-    codecov==2.1.11
+    codecov==2.1.13
     sphinx==1.8.5
     twine==1.15.0
 

--- a/tests/views/test_user.py
+++ b/tests/views/test_user.py
@@ -6,6 +6,8 @@ Tests for the `fonzie` user module.
 # pylint: disable=no-member,import-error
 from __future__ import absolute_import, unicode_literals
 
+import random
+
 import jwt
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -44,6 +46,9 @@ class UserViewTestCase(APITestCase):
         user = UserFactory.create(
             username="fonzie",
             email="arthur_fonzarelli@fun-mooc.fr",
+            is_active=random.choice([True, False]),
+            is_staff=random.choice([True, False]),
+            is_superuser=random.choice([True, False]),
         )
         UserProfileFactory.build(user=user, name="Arthur Fonzarelli")
         self.client.force_authenticate(user=user)
@@ -53,7 +58,18 @@ class UserViewTestCase(APITestCase):
             response.data["access_token"],
             "ThisIsAnExampleKeyForDevPurposeOnly",
             options={
-                "require": ["email", "exp", "iat", "jti", "token_type", "username", "language"]
+                "require": [
+                    "email",
+                    "exp",
+                    "iat",
+                    "jti",
+                    "token_type",
+                    "username",
+                    "language",
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                ]
             },
         )
 
@@ -62,6 +78,9 @@ class UserViewTestCase(APITestCase):
         self.assertEqual(token["username"], "fonzie")
         self.assertEqual(token["full_name"], "Arthur Fonzarelli")
         self.assertEqual(token["email"], "arthur_fonzarelli@fun-mooc.fr")
+        self.assertEqual(token["is_active"], user.is_active)
+        self.assertEqual(token["is_staff"], user.is_staff)
+        self.assertEqual(token["is_superuser"], user.is_superuser)
         # When the user has no language preference, LANGUAGE_CODE should be used
         self.assertEqual(token["language"], 'de')
         self.assertEqual(token["token_type"], "access")
@@ -86,8 +105,18 @@ class UserViewTestCase(APITestCase):
             response.data["access_token"],
             "ThisIsAnExampleKeyForDevPurposeOnly",
             options={
-                "require": ["email", "exp", "iat", "jti", "token_type", "username",
-                            "language"]
+                "require": [
+                    "email",
+                    "exp",
+                    "iat",
+                    "jti",
+                    "token_type",
+                    "username",
+                    "language",
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                ]
             },
         )
 


### PR DESCRIPTION
## Purpose

Currently, when user account is inactive as the user view is using the default SessionAuthentication classes the request returns a 403 Forbidden. In other part of OpenEdX, user requests related to its own account are allowed even if the account is inactive. That's why we allowed a user to retrieve its own account information even if its account is inactive. In this way, this API endpoint is iso with the rest of the OpenEdX app.

We took opportunity to fix this issue to bind also more information in this request response. Indeed, we return the user full name in order to use it on consumer. Furthermore, we bind `is_active`, `is_staff` and `is_superuser` flags to token payload.

Then finally we prepare a the release of the version 0.5.0.

## Proposal

Description...

- [x] Fix issue #32
- [x] Bind more information into User/me response
- [x] Create a new minor release 
