### PR TITLE
✨(user) set cross domain csrf token on user get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Set cross domain csrf token on user api get request
+
 ## [0.5.0] - 2023-12-07
 
 ### Added

--- a/edx-platform/config/lms/docker_run_test.py
+++ b/edx-platform/config/lms/docker_run_test.py
@@ -26,6 +26,8 @@ STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 
 ALLOWED_HOSTS = ["*"]
+CORS_ALLOW_INSECURE = True,
+CORS_ORIGIN_ALLOW_ALL = True,
 
 LOGGING['handlers'].update(
     local={'class': 'logging.NullHandler'},


### PR DESCRIPTION
## Purpose

OpenEdX has an API route to update username profile but this one requires to send a cross domain CSRF Token. To ensure that the api consumer has a valid CSRF Token, we decorate the method `get` of the user api to add a `Set-Cookie` header to set the CSRF Token cookie on request.

## Proposal

- [x] Decorate `get` method of the user api to set a cross domain csrf token on request 
